### PR TITLE
Fix saving photos/videos on Android 13

### DIFF
--- a/app/src/main/kotlin/io/github/wykopmobilny/ui/modules/embedview/EmbedViewActivity.kt
+++ b/app/src/main/kotlin/io/github/wykopmobilny/ui/modules/embedview/EmbedViewActivity.kt
@@ -273,6 +273,10 @@ class EmbedViewActivity : BaseActivity(), EmbedView {
     }
 
     private fun checkForWriteReadPermission(): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            // We don't need these permissions for saving videos on Android API >= T
+            return true
+        }
         if (ActivityCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
             return true
         }

--- a/app/src/main/kotlin/io/github/wykopmobilny/ui/modules/photoview/PhotoViewActions.kt
+++ b/app/src/main/kotlin/io/github/wykopmobilny/ui/modules/photoview/PhotoViewActions.kt
@@ -127,6 +127,10 @@ class PhotoViewActions(val context: Context) : PhotoViewCallbacks {
     }
 
     private fun checkForWriteReadPermission(): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            // We don't need these permissions for saving images on Android API >= T
+            return true
+        }
         if (ActivityCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
             return true
         }


### PR DESCRIPTION
RW permissions aren't required to insert file into media storage on Android 13.

Fixes: #402